### PR TITLE
Fix imports for color_list

### DIFF
--- a/utils/metrics.py
+++ b/utils/metrics.py
@@ -1,0 +1,18 @@
+"""Minimal metrics utilities required for import."""
+import numpy as np
+
+
+def fitness(x):
+    """Return fitness for hyperparameter evolution.
+
+    Args:
+        x (array-like): Metrics array where first four columns correspond
+            to [precision, recall, mAP@0.5, mAP@0.5:0.95].
+    Returns:
+        numpy.ndarray: Weighted fitness value per row.
+    """
+    x = np.array(x)
+    if x.ndim == 1:
+        x = x.reshape(1, -1)
+    w = np.array([0.0, 0.0, 0.1, 0.9])
+    return (x[:, :4] * w).sum(1)


### PR DESCRIPTION
## Summary
- add a minimal `utils.metrics` module with `fitness()`
- let `models.common` import `color_list` without errors

## Testing
- `python -m py_compile $(git ls-files '*.py')`
- `python - <<'EOF'
import models.common
print('ok')
EOF`

------
https://chatgpt.com/codex/tasks/task_e_688b162fef00832eb412e0bee5fd6156